### PR TITLE
Changed default file extension to .jsx

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ function install(options) {
   // Import everything in the transformer codepath before we add the import hook
   React.transform('', options);
 
-  require.extensions[options.extension || '.js'] = function(module, filename) {
+  require.extensions[options.extension || '.jsx'] = function(module, filename) {
     var src = fs.readFileSync(filename, {encoding: 'utf8'});
     if (typeof options.additionalTransform == 'function') {
       src = options.additionalTransform(src);


### PR DESCRIPTION
This improves start up performance as it is now only calling transform on a much smaller fraction of files.

I do appreciate this change will potentially break some people's current implementations - I'm not sure what to suggest. Does this need to be saved for 1.0 / another version?